### PR TITLE
Adding Literal Enum support.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,8 +23,11 @@ npm i --save @intrinsicai/gbnfgen
 ```typescript
 import { compile, serializeGrammar } from "@intrinsicai/gbnfgen";
 
+// Supporting Enum for multiple choices (cannot be numbers)
 const grammar = compile(
-    `interface Person {
+    `enum Mood { Happy, Sad, Grateful, Excited, Angry, Peaceful }
+    
+    interface Person {
          name: string;
          occupation: string;
          age: number;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,13 +1,13 @@
 {
-  "name": "@intrinsic-labs/gbnfgen",
-  "version": "0.2.0",
+  "name": "@intrinsicai/gbnfgen",
+  "version": "0.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@intrinsic-labs/gbnfgen",
-      "version": "0.2.0",
-      "license": "ISC",
+      "name": "@intrinsicai/gbnfgen",
+      "version": "0.0.0",
+      "license": "MIT",
       "devDependencies": {
         "ts-node": "^10.9.1",
         "typescript": "^5.1.6",
@@ -723,9 +723,9 @@
       }
     },
     "node_modules/get-func-name": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.0.tgz",
-      "integrity": "sha512-Hm0ixYtaSZ/V7C8FJrtZIuBBI+iSgL+1Aq82zSu8VQNB4S3Gk8e7Qs3VwBDJAhmRZcFqkl3tQu36g/Foh5I5ig==",
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/get-func-name/-/get-func-name-2.0.2.tgz",
+      "integrity": "sha512-8vXOvuE167CtIc3OyItco7N/dpRtBbYOsPsXCz7X/PMnlGjYjSGuZJgM1Y7mmew7BKf9BqvLX2tnOVy1BBUsxQ==",
       "dev": true,
       "engines": {
         "node": "*"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "git-version": "npm version $(git describe --tags --always --first-parent)",
     "exec": "tsc && node ./dist/grammarTest.js",
-    "test": "echo \"Error: no test specified\" && exit 1"
+    "test": "vitest"
   },
   "type": "module",
   "author": "Intrinsic Labs",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "types": "dist/index.d.ts",
   "scripts": {
     "git-version": "npm version $(git describe --tags --always --first-parent)",
-    "exec": "tsc && node ./dist/grammarTest.js",
+    "build": "tsc",
     "test": "vitest"
   },
   "type": "module",

--- a/src/compiler.test.ts
+++ b/src/compiler.test.ts
@@ -54,7 +54,7 @@ ws ::= [ \t\n]*
 number ::= [0-9]+   "."?   [0-9]*
 stringlist ::= "["   ws   "]" | "["   ws   string   (","   ws   string)*   ws   "]"
 numberlist ::= "["   ws   "]" | "["   ws   string   (","   ws   number)*   ws   "]"
-enumAddressType ::= "business" | "home"`.trim()
+enumAddressType ::= "\"" "business" "\"" | "\"" "home" "\""`.trim()
   )
 });
 
@@ -143,8 +143,8 @@ ws ::= [ \t\n]*
 number ::= [0-9]+   "."?   [0-9]*
 stringlist ::= "["   ws   "]" | "["   ws   string   (","   ws   string)*   ws   "]"
 numberlist ::= "["   ws   "]" | "["   ws   string   (","   ws   number)*   ws   "]"
-enumProductCategory ::= "Electronics" | "Clothing" | "Food"
-enumOrderStatus ::= "Pending" | "Shipped" | "Delivered" | "Canceled"`.trim()
+enumProductCategory ::= "\"" "Electronics" "\"" | "\"" "Clothing" "\"" | "\"" "Food" "\""
+enumOrderStatus ::= "\"" "Pending" "\"" | "\"" "Shipped" "\"" | "\"" "Delivered" "\"" | "\"" "Canceled" "\""`.trim()
   )
 });
 

--- a/src/compiler.test.ts
+++ b/src/compiler.test.ts
@@ -1,6 +1,6 @@
 import { expect, test } from "vitest";
-import { baseGrammar, compile } from "./compiler.js";
-import { Grammar, reference, serializeGrammar } from "./grammar.js";
+import { compile } from "./compiler.js";
+import { serializeGrammar } from "./grammar.js";
 
 test("Single interface generation", () => {
   const postalAddressGrammar = compile(
@@ -26,6 +26,36 @@ number ::= [0-9]+   "."?   [0-9]*
 stringlist ::= "["   ws   "]" | "["   ws   string   (","   ws   string)*   ws   "]"
 numberlist ::= "["   ws   "]" | "["   ws   string   (","   ws   number)*   ws   "]"`.trim()
   );
+});
+
+test("Single interface with enum generation", () => {
+  const postalAddressGrammar = compile(
+    `enum AddressType { business, home };
+    interface PostalAddress {
+    streetNumber: number;
+    type: AddressType;
+    street: string;
+    city: string;
+    state: string;
+    postalCode: number;
+  }`,
+    "PostalAddress"
+  );
+  
+  
+  expect(serializeGrammar(postalAddressGrammar).trimEnd()).toEqual(
+    String.raw`
+root ::= PostalAddress
+PostalAddress ::= "{"   ws   "\"streetNumber\":"   ws   number   ","   ws   "\"type\":"   ws   enumAddressType   ","   ws   "\"street\":"   ws   string   ","   ws   "\"city\":"   ws   string   ","   ws   "\"state\":"   ws   string   ","   ws   "\"postalCode\":"   ws   number   "}"
+PostalAddresslist ::= "[]" | "["   ws   PostalAddress   (","   ws   PostalAddress)*   "]"
+string ::= "\""   ([^"]*)   "\""
+boolean ::= "true" | "false"
+ws ::= [ \t\n]*
+number ::= [0-9]+   "."?   [0-9]*
+stringlist ::= "["   ws   "]" | "["   ws   string   (","   ws   string)*   ws   "]"
+numberlist ::= "["   ws   "]" | "["   ws   string   (","   ws   number)*   ws   "]"
+enumAddressType ::= "business" | "home"`.trim()
+  )
 });
 
 test("Single multiple interface with references generation", () => {
@@ -59,6 +89,63 @@ ws ::= [ \t\n]*
 number ::= [0-9]+   "."?   [0-9]*
 stringlist ::= "["   ws   "]" | "["   ws   string   (","   ws   string)*   ws   "]"
 numberlist ::= "["   ws   "]" | "["   ws   string   (","   ws   number)*   ws   "]"`);
+});
+
+test("Single multiple interface and enum with references generation", () => {
+  const resumeGrammar = compile(
+    `
+    // Define an enum for product categories
+    enum ProductCategory {
+      Electronics,
+      Clothing,
+      Food
+    }
+    
+    // Define an interface for representing a product
+    interface Product {
+      id: number;
+      name: string;
+      description: string;
+      price: number;
+      category: ProductCategory;
+    }
+    
+    // Define an enum for order statuses
+    enum OrderStatus {
+      Pending,
+      Shipped,
+      Delivered,
+      Canceled
+    }
+    
+    // Define an interface for representing an order
+    interface Order {
+      orderId: number;
+      products: Product[];
+      status: OrderStatus;
+      orderDate: string;
+    }
+  `,
+    "Order"
+  );
+  
+
+  expect(serializeGrammar(resumeGrammar).trimEnd()).toEqual(
+    String.raw`
+root ::= Order
+Order ::= "{"   ws   "\"orderId\":"   ws   number   ","   ws   "\"products\":"   ws   Productlist   ","   ws   "\"status\":"   ws   enumOrderStatus   ","   ws   "\"orderDate\":"   ws   string   "}"
+Orderlist ::= "[]" | "["   ws   Order   (","   ws   Order)*   "]"
+Product ::= "{"   ws   "\"id\":"   ws   number   ","   ws   "\"name\":"   ws   string   ","   ws   "\"description\":"   ws   string   ","   ws   "\"price\":"   ws   number   ","   ws   "\"category\":"   ws   enumProductCategory   "}"
+Productlist ::= "[]" | "["   ws   Product   (","   ws   Product)*   "]"
+string ::= "\""   ([^"]*)   "\""
+boolean ::= "true" | "false"
+ws ::= [ \t\n]*
+number ::= [0-9]+   "."?   [0-9]*
+stringlist ::= "["   ws   "]" | "["   ws   string   (","   ws   string)*   ws   "]"
+numberlist ::= "["   ws   "]" | "["   ws   string   (","   ws   number)*   ws   "]"
+enumProductCategory ::= "Electronics" | "Clothing" | "Food"
+enumOrderStatus ::= "Pending" | "Shipped" | "Delivered" | "Canceled"`.trim()
+  )
 });
 
 test("Jsonformer car example", () => {

--- a/src/compiler.ts
+++ b/src/compiler.ts
@@ -124,7 +124,7 @@ function handleEnum(enumNode: EnumDeclaration): GrammarElement {
   if (enumNode && enumNode.members) {
     for (const member of enumNode.members) {
       if (ts.isEnumMember(member) && member.name && ts.isIdentifier(member.name)) {
-        choices.push(literal(member.name.text));
+        choices.push(literal(member.name.text, true));
       }
     }
   }
@@ -197,7 +197,7 @@ function handleInterface(
  * @param source
  * @returns
  */
-export function compile(source: string, rootType: string, enums?: string): Grammar {
+export function compile(source: string, rootType: string): Grammar {
   const host = createInMemoryCompilerHost();
 
   const srcFile = host.addSource("source.ts", source);

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -28,6 +28,7 @@ export interface RuleGroup {
 export interface RuleLiteral {
   type: "literal";
   literal: string;
+  quote: boolean;
 }
 
 export interface RuleReference {
@@ -90,7 +91,7 @@ function serializeGroup(rule: RuleGroup): string {
 }
 
 function serializeLiteralRule(rule: RuleLiteral): string {
-  return JSON.stringify(rule.literal);
+  return rule.quote ? "\"\\\"\" " + JSON.stringify(rule.literal) + " \"\\\"\"" : JSON.stringify(rule.literal);
 }
 
 function serializeReference(rule: RuleReference): string {
@@ -135,10 +136,11 @@ export function serializeGrammar(grammar: Grammar): string {
   return out;
 }
 
-export function literal(value: string): RuleLiteral {
+export function literal(value: string, quote: boolean=false): RuleLiteral {
   return {
     type: "literal",
     literal: value,
+    quote: quote,
   };
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,114 @@
+import {
+  GrammarElement,
+  GrammarRule,
+  RuleReference,
+  charPattern,
+  group,
+  literal,
+  reference,
+  sequence,
+} from "./grammar.js";
+
+// ----- Default Grammar Register ----- //
+
+const WS_ELEM: GrammarElement = {
+  identifier: "ws",
+  alternatives: [charPattern(/[ \t\n]*/g)],
+};
+
+const STRING_ELEM: GrammarElement = {
+  identifier: "string",
+  alternatives: [sequence(literal(`"`), charPattern(/([^"]*)/g), literal(`"`))],
+};
+const BOOLEAN_ELEM: GrammarElement = {
+  identifier: "boolean",
+  alternatives: [
+    literal(`true`),
+    literal(`false`),
+  ]
+}
+const NUMBER_ELEM: GrammarElement = {
+  identifier: "number",
+  alternatives: [
+    sequence(
+      charPattern(/[0-9]+/g),
+      charPattern(/"."?/g),
+      charPattern(/[0-9]*/g)
+    ),
+  ],
+};
+
+export const STRING_REF = reference(STRING_ELEM.identifier);
+export const NUMBER_REF = reference(NUMBER_ELEM.identifier);
+export const WS_REF: RuleReference = reference(WS_ELEM.identifier);
+
+const NUMBERLIST_ELEM: GrammarElement = {
+  identifier: "numberlist",
+  alternatives: [
+    // Empty list
+    sequence(literal(`[`), WS_REF, literal(`]`)),
+
+    // Non-empty list
+    sequence(
+      literal(`[`),
+      WS_REF,
+      STRING_REF,
+      group(sequence(literal(`,`), WS_REF, NUMBER_REF), "star"),
+      WS_REF,
+      literal(`]`)
+    ),
+  ],
+};
+const STRINGLIST_ELEM: GrammarElement = {
+  identifier: "stringlist",
+  alternatives: [
+    // Empty list
+    sequence(literal(`[`), WS_REF, literal(`]`)),
+
+    // Non-empty list
+    sequence(
+      literal(`[`),
+      WS_REF,
+      STRING_REF,
+      group(sequence(literal(`,`), WS_REF, STRING_REF), "star"),
+      WS_REF,
+      literal(`]`)
+    ),
+  ],
+};
+
+
+export type GrammarRegister = Map<string, Array<GrammarRule>>;
+
+/**
+ * Create the default grammar element register.
+ * Enables Enum add to the register when compiling the source file.
+ * @returns The Default Grammar Element Register
+ */
+export function getGrammarRegister(): GrammarRegister {
+  const register = new Map<string, Array<GrammarRule>>();
+  
+  register.set(STRING_ELEM.identifier, STRING_ELEM.alternatives);
+  register.set(BOOLEAN_ELEM.identifier, BOOLEAN_ELEM.alternatives);
+  register.set(WS_ELEM.identifier, WS_ELEM.alternatives);
+  register.set(NUMBER_ELEM.identifier, NUMBER_ELEM.alternatives);
+  register.set(STRINGLIST_ELEM.identifier, STRINGLIST_ELEM.alternatives);
+  register.set(NUMBERLIST_ELEM.identifier, NUMBERLIST_ELEM.alternatives);
+  return register;
+}
+
+export function registerToGrammar(register: GrammarRegister): Array<GrammarElement> {
+  return Array.from(register.entries()).map(([identifier, alternatives]) => ({ identifier, alternatives }));
+}
+
+// ----- Element Identifier Helpers ----- //
+type ElementIdentifier = string;
+
+export function toElementId(ifaceName: string): ElementIdentifier {
+  const pattern = /[^a-zA-Z0-9]/g;
+  return ifaceName.replace(pattern, "");
+}
+
+export function toListElementId(ifaceName: string): ElementIdentifier {
+  return `${toElementId(ifaceName)}list`;
+}


### PR DESCRIPTION
Adding Enum support with the following format:

```typescript
enum EnumName { ChoiceA, ChoiceB, ChoiceC }
```

So we can have the following interface: 

```typescript
enum Tool { WebSearch, Wikipedia, Calculator, FileRead, FileWrite }

interface ReAct {
  select: Tool;
  reason: string;
}
```

With the following output

```txt
root ::= ReAct
ReAct ::= "{"   ws   "\"select\":"   ws   enumTool   ","   ws   "\"reason\":"   ws   string   "}"
ReActlist ::= "[]" | "["   ws   ReAct   (","   ws   ReAct)*   "]"
string ::= "\""   ([^"]*)   "\""
boolean ::= "true" | "false"
ws ::= [ \t\n]*
number ::= [0-9]+   "."?   [0-9]*
stringlist ::= "["   ws   "]" | "["   ws   string   (","   ws   string)*   ws   "]"
numberlist ::= "["   ws   "]" | "["   ws   string   (","   ws   number)*   ws   "]"
enumTool ::= "\"" "WebSearch" "\"" | "\"" "Wikipedia" "\"" | "\"" "Calculator" "\"" | "\"" "FileRead" "\"" | "\"" "FileWrite" "\""
```

The additional code provides the default Grammar Register with original grammar elements and then adds dynamic Enum Grammar Elements based on the source file.

Also, separate some helper functions into `util.py`.