### PR TITLE
Small tweaks on top of #2

### DIFF
--- a/.github/workflows/npm.yml
+++ b/.github/workflows/npm.yml
@@ -13,7 +13,7 @@ jobs:
           node-version: '16.x'
           registry-url: 'https://registry.npmjs.org'
       - run: npm ci
-      - run: npx tsc
+      - run: npm run build
       - run: npm --no-git-tag-version version from-git
       - run: npm publish --access public
         env:

--- a/README.md
+++ b/README.md
@@ -25,12 +25,20 @@ import { compile, serializeGrammar } from "@intrinsicai/gbnfgen";
 
 // Supporting Enum for multiple choices (cannot be numbers)
 const grammar = compile(
-    `enum Mood { Happy, Sad, Grateful, Excited, Angry, Peaceful }
+    `enum Mood {
+      Happy = "happy",
+      Sad = "sad",
+      Grateful = "grateful",
+      Excited = "excited", 
+      Angry = "angry, 
+      Peaceful = "peaceful"
+    }
     
     interface Person {
          name: string;
          occupation: string;
          age: number;
+         mood: Mood,
      }`, "Person");
 ```
 

--- a/src/compiler.test.ts
+++ b/src/compiler.test.ts
@@ -30,7 +30,7 @@ numberlist ::= "["   ws   "]" | "["   ws   string   (","   ws   number)*   ws   
 
 test("Single interface with enum generation", () => {
   const postalAddressGrammar = compile(
-    `enum AddressType { business, home };
+    `enum AddressType { Business = "business", Home = "home" };
     interface PostalAddress {
     streetNumber: number;
     type: AddressType;
@@ -41,21 +41,21 @@ test("Single interface with enum generation", () => {
   }`,
     "PostalAddress"
   );
-  
-  
+
   expect(serializeGrammar(postalAddressGrammar).trimEnd()).toEqual(
     String.raw`
 root ::= PostalAddress
-PostalAddress ::= "{"   ws   "\"streetNumber\":"   ws   number   ","   ws   "\"type\":"   ws   enumAddressType   ","   ws   "\"street\":"   ws   string   ","   ws   "\"city\":"   ws   string   ","   ws   "\"state\":"   ws   string   ","   ws   "\"postalCode\":"   ws   number   "}"
+PostalAddress ::= "{"   ws   "\"streetNumber\":"   ws   number   ","   ws   "\"type\":"   ws   AddressType   ","   ws   "\"street\":"   ws   string   ","   ws   "\"city\":"   ws   string   ","   ws   "\"state\":"   ws   string   ","   ws   "\"postalCode\":"   ws   number   "}"
 PostalAddresslist ::= "[]" | "["   ws   PostalAddress   (","   ws   PostalAddress)*   "]"
+AddressType ::= "\"" "business" "\"" | "\"" "home" "\""
 string ::= "\""   ([^"]*)   "\""
 boolean ::= "true" | "false"
 ws ::= [ \t\n]*
 number ::= [0-9]+   "."?   [0-9]*
 stringlist ::= "["   ws   "]" | "["   ws   string   (","   ws   string)*   ws   "]"
 numberlist ::= "["   ws   "]" | "["   ws   string   (","   ws   number)*   ws   "]"
-enumAddressType ::= "\"" "business" "\"" | "\"" "home" "\""`.trim()
-  )
+`.trim()
+  );
 });
 
 test("Single multiple interface with references generation", () => {
@@ -96,9 +96,9 @@ test("Single multiple interface and enum with references generation", () => {
     `
     // Define an enum for product categories
     enum ProductCategory {
-      Electronics,
-      Clothing,
-      Food
+      Electronics = "Electronics",
+      Clothing = "Clothing",
+      Food = "Food"
     }
     
     // Define an interface for representing a product
@@ -112,10 +112,10 @@ test("Single multiple interface and enum with references generation", () => {
     
     // Define an enum for order statuses
     enum OrderStatus {
-      Pending,
-      Shipped,
-      Delivered,
-      Canceled
+      Pending = "Pending",
+      Shipped = "Shipped",
+      Delivered = "Delivered",
+      Canceled = "Canceled"
     }
     
     // Define an interface for representing an order
@@ -128,24 +128,24 @@ test("Single multiple interface and enum with references generation", () => {
   `,
     "Order"
   );
-  
 
   expect(serializeGrammar(resumeGrammar).trimEnd()).toEqual(
     String.raw`
 root ::= Order
-Order ::= "{"   ws   "\"orderId\":"   ws   number   ","   ws   "\"products\":"   ws   Productlist   ","   ws   "\"status\":"   ws   enumOrderStatus   ","   ws   "\"orderDate\":"   ws   string   "}"
+Order ::= "{"   ws   "\"orderId\":"   ws   number   ","   ws   "\"products\":"   ws   Productlist   ","   ws   "\"status\":"   ws   OrderStatus   ","   ws   "\"orderDate\":"   ws   string   "}"
 Orderlist ::= "[]" | "["   ws   Order   (","   ws   Order)*   "]"
-Product ::= "{"   ws   "\"id\":"   ws   number   ","   ws   "\"name\":"   ws   string   ","   ws   "\"description\":"   ws   string   ","   ws   "\"price\":"   ws   number   ","   ws   "\"category\":"   ws   enumProductCategory   "}"
+OrderStatus ::= "\"" "Pending" "\"" | "\"" "Shipped" "\"" | "\"" "Delivered" "\"" | "\"" "Canceled" "\""
+Product ::= "{"   ws   "\"id\":"   ws   number   ","   ws   "\"name\":"   ws   string   ","   ws   "\"description\":"   ws   string   ","   ws   "\"price\":"   ws   number   ","   ws   "\"category\":"   ws   ProductCategory   "}"
 Productlist ::= "[]" | "["   ws   Product   (","   ws   Product)*   "]"
+ProductCategory ::= "\"" "Electronics" "\"" | "\"" "Clothing" "\"" | "\"" "Food" "\""
 string ::= "\""   ([^"]*)   "\""
 boolean ::= "true" | "false"
 ws ::= [ \t\n]*
 number ::= [0-9]+   "."?   [0-9]*
 stringlist ::= "["   ws   "]" | "["   ws   string   (","   ws   string)*   ws   "]"
 numberlist ::= "["   ws   "]" | "["   ws   string   (","   ws   number)*   ws   "]"
-enumProductCategory ::= "\"" "Electronics" "\"" | "\"" "Clothing" "\"" | "\"" "Food" "\""
-enumOrderStatus ::= "\"" "Pending" "\"" | "\"" "Shipped" "\"" | "\"" "Delivered" "\"" | "\"" "Canceled" "\""`.trim()
-  )
+`.trim()
+  );
 });
 
 test("Jsonformer car example", () => {

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -82,16 +82,18 @@ function serializeSequence(rule: RuleSequence): string {
 
 function serializeGroup(rule: RuleGroup): string {
   const multiplicity = {
-    "none": "",
-    "optional": "?",
-    "star": "*",
-    "plus": "+",
+    none: "",
+    optional: "?",
+    star: "*",
+    plus: "+",
   }[rule.multiplicity];
   return `(${serializeSequence(rule.rules)})${multiplicity}`;
 }
 
 function serializeLiteralRule(rule: RuleLiteral): string {
-  return rule.quote ? "\"\\\"\" " + JSON.stringify(rule.literal) + " \"\\\"\"" : JSON.stringify(rule.literal);
+  return rule.quote
+    ? '"\\"" ' + JSON.stringify(rule.literal) + ' "\\""'
+    : JSON.stringify(rule.literal);
 }
 
 function serializeReference(rule: RuleReference): string {
@@ -136,7 +138,7 @@ export function serializeGrammar(grammar: Grammar): string {
   return out;
 }
 
-export function literal(value: string, quote: boolean=false): RuleLiteral {
+export function literal(value: string, quote: boolean = false): RuleLiteral {
   return {
     type: "literal",
     literal: value,
@@ -165,10 +167,13 @@ export function reference(value: string): RuleReference {
   };
 }
 
-export function group(rules: RuleSequence, multiplicity: RuleGroup["multiplicity"]): RuleGroup {
+export function group(
+  rules: RuleSequence,
+  multiplicity: RuleGroup["multiplicity"]
+): RuleGroup {
   return {
     type: "group",
     rules,
     multiplicity,
-  }
+  };
 }

--- a/src/util.ts
+++ b/src/util.ts
@@ -85,7 +85,7 @@ export type GrammarRegister = Map<string, Array<GrammarRule>>;
  * Enables Enum add to the register when compiling the source file.
  * @returns The Default Grammar Element Register
  */
-export function getGrammarRegister(): GrammarRegister {
+export function getDefaultGrammar(): GrammarRegister {
   const register = new Map<string, Array<GrammarRule>>();
   
   register.set(STRING_ELEM.identifier, STRING_ELEM.alternatives);


### PR DESCRIPTION
Couple of cleanups

- Enforcing that all enums are String enums. By default in TypeScript, enums are numeric enums if you don't provide an initializer https://www.typescriptlang.org/docs/handbook/enums.html
- Adding string initializers to all tests
- Removing the need for `enum${X}` as the rule name for grammars. Enum grammar rules should be opaque type references as far as Interfaces are concerned.
- Change some control flow to be consistent with the existing control flow for parsing the AST for interfaces