### PR TITLE
Add dependabot file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,13 @@
+# To get started with Dependabot version updates, you'll need to specify which
+# package ecosystems to update and where the package manifests are located.
+# Please see the documentation for all configuration options:
+# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
+
+version: 2
+updates:
+  - package-ecosystem: "npm"
+    directory: "/"
+    schedule:
+      interval: "daily"
+      time: "09:30"
+      timezone: "America/New_York"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "git-version": "npm version $(git describe --tags --always --first-parent)",
     "build": "tsc",
-    "test": "vitest"
+    "test": "vitest run"
   },
   "type": "module",
   "author": "Intrinsic Labs",


### PR DESCRIPTION
Turn on dependabot so that we stay up to date with dependency changes.

Need to also figure out how to auto-tag new releases on each merge that passes tests.