### PR TITLE
Add support for union type literals in general

### DIFF
--- a/src/compiler.test.ts
+++ b/src/compiler.test.ts
@@ -2,6 +2,27 @@ import { expect, test } from "vitest";
 import { compile, compileSync } from "./compiler.js";
 import { serializeGrammar } from "./grammar.js";
 
+test("union types", () => {
+  const grammar = compileSync(`
+  interface Person {
+    age: number | string;
+  }
+  `, "Person"
+  );
+
+  expect(serializeGrammar(grammar).trimEnd()).toEqual(
+    String.raw`
+root ::= Person
+Person ::= "{"   ws   "\"age\":"   ws   (  string | number  )   "}"
+Personlist ::= "[]" | "["   ws   Person   (","   ws   Person)*   "]"
+string ::= "\""   ([^"]*)   "\""
+boolean ::= "true" | "false"
+ws ::= [ \t\n]*
+number ::= [0-9]+   "."?   [0-9]*
+stringlist ::= "["   ws   "]" | "["   ws   string   (","   ws   string)*   ws   "]"
+numberlist ::= "["   ws   "]" | "["   ws   string   (","   ws   number)*   ws   "]"`.trim())
+});
+
 test("Single interface generation", () => {
   const postalAddressGrammar = compileSync(
     `interface PostalAddress {

--- a/src/compiler.test.ts
+++ b/src/compiler.test.ts
@@ -5,7 +5,7 @@ import { serializeGrammar } from "./grammar.js";
 test("union types", () => {
   const grammar = compileSync(`
   interface Person {
-    age: number | string;
+    age: number[] | string[];
   }
   `, "Person"
   );
@@ -13,7 +13,7 @@ test("union types", () => {
   expect(serializeGrammar(grammar).trimEnd()).toEqual(
     String.raw`
 root ::= Person
-Person ::= "{"   ws   "\"age\":"   ws   (  string | number  )   "}"
+Person ::= "{"   ws   "\"age\":"   ws   (  stringlist | numberlist  )   "}"
 Personlist ::= "[]" | "["   ws   Person   (","   ws   Person)*   "]"
 string ::= "\""   ([^"]*)   "\""
 boolean ::= "true" | "false"

--- a/src/grammar.ts
+++ b/src/grammar.ts
@@ -9,6 +9,7 @@ export interface GrammarElement {
 
 export type GrammarRule =
   | RuleSequence
+  | RuleAlternatives
   | RuleGroup
   | RuleLiteral
   | RuleReference
@@ -16,6 +17,11 @@ export type GrammarRule =
 
 export interface RuleSequence {
   type: "sequence";
+  rules: Array<GrammarRule>;
+}
+
+export interface RuleAlternatives {
+  type: "alt";
   rules: Array<GrammarRule>;
 }
 
@@ -44,6 +50,10 @@ export function isSequence(rule: GrammarRule): rule is RuleSequence {
   return rule.type === "sequence";
 }
 
+export function isAlternatives(rule: GrammarRule): rule is RuleAlternatives {
+  return rule.type === "alt";
+}
+
 export function isGroup(rule: GrammarRule): rule is RuleGroup {
   return rule.type === "group";
 }
@@ -65,6 +75,8 @@ function serializeRule(rule: GrammarRule): string {
     return serializeSequence(rule);
   } else if (isGroup(rule)) {
     return serializeGroup(rule);
+  } else if (isAlternatives(rule)) {
+    return serializeAlternatives(rule)
   } else if (isLiteral(rule)) {
     return serializeLiteralRule(rule);
   } else if (isReference(rule)) {
@@ -87,6 +99,11 @@ function serializeGroup(rule: RuleGroup): string {
     plus: "+",
   }[rule.multiplicity];
   return `(${serializeSequence(rule.rules)})${multiplicity}`;
+}
+
+function serializeAlternatives(alt: RuleAlternatives): string {
+  const alternatives = alt.rules.map(rule => serializeRule(rule));
+  return "(  " + alternatives.join(" | ") + "  )";
 }
 
 function serializeLiteralRule(rule: RuleLiteral): string {
@@ -161,6 +178,13 @@ export function reference(value: string): RuleReference {
     type: "reference",
     referee: value,
   };
+}
+
+export function alternatives(...values: Array<GrammarRule>): RuleAlternatives {
+  return {
+    type: "alt",
+    rules: values,
+  }
 }
 
 export function group(


### PR DESCRIPTION
Add support for type literals

Can be used to support #25 for example

```typescript
interface Person {
  stringsOrNumbers: string[] | number[];
}
```