### PR TITLE
Fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ const grammar = compile(
       Sad = "sad",
       Grateful = "grateful",
       Excited = "excited", 
-      Angry = "angry, 
+      Angry = "angry", 
       Peaceful = "peaceful"
     }
     


### PR DESCRIPTION
Added a missing `"` to the Quickstart Example